### PR TITLE
Fix docs server task id recomendation.

### DIFF
--- a/DEVELOPERS_GUIDE.md
+++ b/DEVELOPERS_GUIDE.md
@@ -25,5 +25,5 @@ steps:
       OCTOPUS_URL: ${{ secrets.SERVER }}
       OCTOPUS_SPACE: 'Outer Space'
     with:
-      server_task_id: {{ steps.some_previous_deployment_step.outputs.server_tasks[0].server_task_id }}
+      server_task_id: ${{ fromJson(steps.some_previous_deployment_step.outputs.server_tasks)[0].serverTaskId }}
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ steps:
       OCTOPUS_URL: ${{ secrets.SERVER }}
       OCTOPUS_SPACE: 'Outer Space'
     with:
-      server_task_id: {{ steps.some_previous_deployment_step.outputs.server_tasks[0].server_task_id }}
+      server_task_id: ${{ fromJson(steps.some_previous_deployment_step.outputs.server_tasks)[0].serverTaskId }}
 ```
 
 ## ✍️ Environment Variables


### PR DESCRIPTION
Currently the docs recommend fetching the server_task_id via `{{steps.some_previous_deployment_step.outputs.server_tasks[0].server_task_id }}`. This fails retrieving the task id
![image](https://user-images.githubusercontent.com/101079287/231608429-eb9990c8-bf9f-42a6-9985-8fd015894eb2.png)

The original [GitHub actions blog post](https://octopus.com/blog/github-actions-for-octopus-deploy-v3#all-in-one) recommends the approach below:
`${{fromJson(steps.some_previous_deployment_step.outputs.server_tasks)[0].serverTaskId }}` which works. 

[sc-45926]