### PR TITLE
Read timeout value from correct input

### DIFF
--- a/src/input-parameters.ts
+++ b/src/input-parameters.ts
@@ -43,7 +43,7 @@ export function getInputParameters(): InputParameters {
   }
 
   let timeout = 600
-  const timeoutInput = getInput('timeout')
+  const timeoutInput = getInput('timeout-after')
   if (timeoutInput) {
     timeout = parseInt(timeoutInput)
   }


### PR DESCRIPTION
The api client was not respecting the timeout value and was fixed in https://github.com/OctopusDeploy/api-client.ts/commit/75fe0591da8a3dac8ef8998a72333a5ab0ae32cb#diff-9c07c3708d55cddb596d6119d648e446b9b1c8a94e7719d9d6d7c5739bc5da13 

However this now highlights another problem, where the action isn't passing to the client the value set in the input timeout_after parameter.
