### PR TITLE
Add slack notification for scheduled build failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Slack - Notify on nightly build failure
     needs: [test]
-    # if: ${{ github.event_name == 'schedule' && failure() }}
+    if: ${{ github.event_name == 'schedule' && failure() }}
 
     steps:
       - name: Notify

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Notify
         uses: voxmedia/github-action-slack-notify-build@v1.6.0
         with:
-          channel: ${{ secrets.SLACK_NOTIFICATIONS_CHANNEL }}
+          channel_id: ${{ secrets.SLACK_NOTIFICATIONS_CHANNEL_ID }}
           status: FAILED
           color: danger
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
 
     steps:
       - name: Notify
-        uses: voxmedia/github-action-slack-notify-build@v1.6.0
+        uses: zuplo/github-action-slack-notify-build@v2
         with:
           channel_id: ${{ secrets.SLACK_NOTIFICATIONS_CHANNEL_ID }}
           status: FAILED

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,3 +103,19 @@ jobs:
 
     - name: Echo success status from self-test-2
       run: echo "Deployment succeeded = [${{ steps.self_test_2.outputs.task_state }}]"
+
+  notify: 
+    runs-on: ubuntu-latest
+    name: Slack - Notify on nightly build failure
+    needs: [test]
+    # if: ${{ github.event_name == 'schedule' && failure() }}
+
+    steps:
+      - name: Notify
+        uses: voxmedia/github-action-slack-notify-build@v1.6.0
+        with:
+          channel: ${{ secrets.SLACK_NOTIFICATIONS_CHANNEL }}
+          status: FAILED
+          color: danger
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_TOKEN }}


### PR DESCRIPTION
Currently if there are scheduled build failures then some team members seem to get emails, but others don't. This might be due to filters, or perhaps it's whoever last did a commit to the repo? Either way it's not ideal, so this PR adds a step to the build which will send a notification to the team in slack.