### PR TITLE
chore: Add manual dispatch to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 name: release-please
 env:
   ACTION_NAME: create-release-action


### PR DESCRIPTION
## What's this? 🌵 

This PR enables us to manually run the release-please action. This will be useful in situations like wanting to update a changes summary PR generated by release-please.

## Testing 🧪 

This can't be tested until it's on main but I've picked over the workflow code and checked the values being referenced. Everything looks like it should be available on manual dispatch. We are using a [DEVEX_BOT_TOKEN](https://github.com/OctopusDeploy/await-task-action/blob/main/.github/workflows/release-please.yml#L41) but this seems to be just a [regular actions repository secret.](https://github.com/OctopusDeploy/await-task-action/settings/secrets/actions)

Part of DEVEX-223